### PR TITLE
Gas golfing structs

### DIFF
--- a/src/Structs.sol
+++ b/src/Structs.sol
@@ -24,15 +24,15 @@ struct StartBattleArgs {
 
 struct Battle {
     address p0;
-    uint96 p1TeamIndex;
     address p1;
+    ITeamRegistry teamRegistry;
     IValidator validator;
     IRandomnessOracle rngOracle;
     IRuleset ruleset;
-    BattleProposalStatus status;
-    ITeamRegistry teamRegistry;
     bytes32 p0TeamHash;
     Mon[][] teams;
+    BattleProposalStatus status;
+    uint96 p1TeamIndex;
 }
 
 struct BattleState {


### PR DESCRIPTION
Looks like with the latest changes, this would save 16 bytes now compared to the 44 previously talked about.

Before:
![image](https://github.com/user-attachments/assets/95d4903f-0c35-46f8-a290-0c29ed90f7af)


After:
![image](https://github.com/user-attachments/assets/9dd64601-b3e8-4d3f-bd9c-232cf9b76c32)
