### PR TITLE
Refactor engineHook to engineHooks array in Battle struct

### DIFF
--- a/src/Engine.sol
+++ b/src/Engine.sol
@@ -152,8 +152,10 @@ contract Engine is IEngine {
         // Set flag to be 2 which means both players act
         battleStates[battleKey].playerSwitchForTurnFlag = 2;
 
-        if (address(battle.engineHook) != address(0)) {
-            battle.engineHook.onBattleStart(battleKey);
+        for (uint256 i = 0; i < battle.engineHooks.length; i++) {
+            if (address(battle.engineHooks[i]) != address(0)) {
+                battle.engineHooks[i].onBattleStart(battleKey);
+            }
         }
 
         emit BattleStart(battleKey, battle.p0, battle.p1);
@@ -182,8 +184,10 @@ contract Engine is IEngine {
         // (gets cleared at the end of the transaction)
         battleKeyForWrite = battleKey;
 
-        if (address(battle.engineHook) != address(0)) {
-            battle.engineHook.onRoundStart(battleKey);
+        for (uint256 i = 0; i < battle.engineHooks.length; i++) {
+            if (address(battle.engineHooks[i]) != address(0)) {
+                battle.engineHooks[i].onRoundStart(battleKey);
+            }
         }
 
         // If only a single player has a move to submit, then we don't trigger any effects
@@ -365,16 +369,20 @@ contract Engine is IEngine {
 
         // Progress turn index and finally set the player switch for turn flag on the state
         if (state.winner != address(0)) {
-            if (address(battle.engineHook) != address(0)) {
-                battle.engineHook.onBattleEnd(battleKey);
+            for (uint256 i = 0; i < battle.engineHooks.length; i++) {
+                if (address(battle.engineHooks[i]) != address(0)) {
+                    battle.engineHooks[i].onBattleEnd(battleKey);
+                }
             }
             return;
         }
         state.turnId += 1;
         state.playerSwitchForTurnFlag = playerSwitchForTurnFlag;
 
-        if (address(battle.engineHook) != address(0)) {
-            battle.engineHook.onRoundEnd(battleKey);
+        for (uint256 i = 0; i < battle.engineHooks.length; i++) {
+            if (address(battle.engineHooks[i]) != address(0)) {
+                battle.engineHooks[i].onRoundEnd(battleKey);
+            }
         }
 
         // Emits switch for turn flag for the next turn, but the priority index for this current turn
@@ -392,8 +400,10 @@ contract Engine is IEngine {
             if (potentialLoser != address(0)) {
                 address winner = potentialLoser == battle.p0 ? battle.p1 : battle.p0;
                 state.winner = winner;
-                if (address(battle.engineHook) != address(0)) {
-                    battle.engineHook.onBattleEnd(battleKey);
+                for (uint256 j = 0; j < battle.engineHooks.length; j++) {
+                    if (address(battle.engineHooks[j]) != address(0)) {
+                        battle.engineHooks[j].onBattleEnd(battleKey);
+                    }
                 }
                 emit BattleComplete(battleKey, winner);
                 return;

--- a/src/Engine.sol
+++ b/src/Engine.sol
@@ -153,9 +153,7 @@ contract Engine is IEngine {
         battleStates[battleKey].playerSwitchForTurnFlag = 2;
 
         for (uint256 i = 0; i < battle.engineHooks.length; i++) {
-            if (address(battle.engineHooks[i]) != address(0)) {
-                battle.engineHooks[i].onBattleStart(battleKey);
-            }
+            battle.engineHooks[i].onBattleStart(battleKey);
         }
 
         emit BattleStart(battleKey, battle.p0, battle.p1);
@@ -185,9 +183,7 @@ contract Engine is IEngine {
         battleKeyForWrite = battleKey;
 
         for (uint256 i = 0; i < battle.engineHooks.length; i++) {
-            if (address(battle.engineHooks[i]) != address(0)) {
-                battle.engineHooks[i].onRoundStart(battleKey);
-            }
+            battle.engineHooks[i].onRoundStart(battleKey);
         }
 
         // If only a single player has a move to submit, then we don't trigger any effects
@@ -370,9 +366,7 @@ contract Engine is IEngine {
         // Progress turn index and finally set the player switch for turn flag on the state
         if (state.winner != address(0)) {
             for (uint256 i = 0; i < battle.engineHooks.length; i++) {
-                if (address(battle.engineHooks[i]) != address(0)) {
-                    battle.engineHooks[i].onBattleEnd(battleKey);
-                }
+                battle.engineHooks[i].onBattleEnd(battleKey);
             }
             return;
         }
@@ -380,9 +374,7 @@ contract Engine is IEngine {
         state.playerSwitchForTurnFlag = playerSwitchForTurnFlag;
 
         for (uint256 i = 0; i < battle.engineHooks.length; i++) {
-            if (address(battle.engineHooks[i]) != address(0)) {
-                battle.engineHooks[i].onRoundEnd(battleKey);
-            }
+            battle.engineHooks[i].onRoundEnd(battleKey);
         }
 
         // Emits switch for turn flag for the next turn, but the priority index for this current turn
@@ -401,9 +393,7 @@ contract Engine is IEngine {
                 address winner = potentialLoser == battle.p0 ? battle.p1 : battle.p0;
                 state.winner = winner;
                 for (uint256 j = 0; j < battle.engineHooks.length; j++) {
-                    if (address(battle.engineHooks[j]) != address(0)) {
-                        battle.engineHooks[j].onBattleEnd(battleKey);
-                    }
+                    battle.engineHooks[j].onBattleEnd(battleKey);
                 }
                 emit BattleComplete(battleKey, winner);
                 return;

--- a/src/Structs.sol
+++ b/src/Structs.sol
@@ -23,7 +23,7 @@ struct ProposedBattle {
     IValidator validator;
     IRandomnessOracle rngOracle;
     IRuleset ruleset;
-    IEngineHook engineHook;
+    IEngineHook[] engineHooks;
     IMoveManager moveManager;
     IMatchmaker matchmaker;
 }
@@ -37,7 +37,7 @@ struct Battle {
     IValidator validator;
     IRandomnessOracle rngOracle;
     IRuleset ruleset;
-    IEngineHook engineHook;
+    IEngineHook[] engineHooks;
     IMoveManager moveManager;
     IMatchmaker matchmaker;
     uint96 startTimestamp;

--- a/src/cpu/CPU.sol
+++ b/src/cpu/CPU.sol
@@ -148,7 +148,7 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
                 validator: proposal.validator,
                 rngOracle: proposal.rngOracle,
                 ruleset: proposal.ruleset,
-                engineHook: proposal.engineHook,
+                engineHooks: proposal.engineHooks,
                 moveManager: proposal.moveManager,
                 matchmaker: proposal.matchmaker,
                 startTimestamp: 0,

--- a/src/matchmaker/DefaultMatchmaker.sol
+++ b/src/matchmaker/DefaultMatchmaker.sol
@@ -36,7 +36,7 @@ contract DefaultMatchmaker is IMatchmaker {
                 proposal.rngOracle,
                 proposal.ruleset,
                 proposal.teamRegistry,
-                proposal.engineHook,
+                proposal.engineHooks,
                 proposal.moveManager,
                 proposal.matchmaker
             )
@@ -107,7 +107,7 @@ contract DefaultMatchmaker is IMatchmaker {
                 validator: proposal.validator,
                 rngOracle: proposal.rngOracle,
                 ruleset: proposal.ruleset,
-                engineHook: proposal.engineHook,
+                engineHooks: proposal.engineHooks,
                 moveManager: proposal.moveManager,
                 matchmaker: proposal.matchmaker,
                 startTimestamp: 0, // This gets filled in by the Engine

--- a/test/CPUTest.sol
+++ b/test/CPUTest.sol
@@ -195,7 +195,7 @@ contract CPUTest is Test {
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
             teamRegistry: teamRegistry,
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: cpuMoveManager,
             matchmaker: cpu
         });
@@ -310,7 +310,7 @@ contract CPUTest is Test {
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
             teamRegistry: teamRegistry,
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: playerCPUMoveManager,
             matchmaker: playerCPU
         });
@@ -352,7 +352,7 @@ contract CPUTest is Test {
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
             teamRegistry: teamRegistry,
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: playerCPUMoveManager,
             matchmaker: playerCPU
         });

--- a/test/EngineTest.sol
+++ b/test/EngineTest.sol
@@ -2734,7 +2734,7 @@ contract EngineTest is Test, BattleHelper {
             validator: validatorToUse,
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: IMoveManager(address(0)),
             matchmaker: matchmaker
         });

--- a/test/EngineTest.sol
+++ b/test/EngineTest.sol
@@ -696,7 +696,7 @@ contract EngineTest is Test, BattleHelper {
         defaultRegistry.setTeam(BOB, teams[1]);
 
         bytes32 battleKey = _startBattle(
-            twoMonValidator, engine, defaultOracle, defaultRegistry, matchmaker, IEngineHook(address(0)), rules
+            twoMonValidator, engine, defaultOracle, defaultRegistry, matchmaker, new IEngineHook[](0), rules
         );
 
         // First move of the game has to be selecting their mons (both index 0)

--- a/test/GachaTest.sol
+++ b/test/GachaTest.sol
@@ -121,7 +121,9 @@ contract GachaTest is Test, BattleHelper {
         vm.warp(gachaRegistry.BATTLE_COOLDOWN() + 1);
         FastValidator validator =
             new FastValidator(engine, FastValidator.Args({MONS_PER_TEAM: 1, MOVES_PER_MON: 0, TIMEOUT_DURATION: 0}));
-        bytes32 battleKey = _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, gachaRegistry);
+        IEngineHook[] memory hooks = new IEngineHook[](1);
+        hooks[0] = gachaRegistry;
+        bytes32 battleKey = _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, hooks);
 
         // Alice commits switching to mon index 0
         vm.startPrank(ALICE);
@@ -190,8 +192,10 @@ contract GachaTest is Test, BattleHelper {
             FastValidator validator = new FastValidator(
                 engine, FastValidator.Args({MONS_PER_TEAM: 1, MOVES_PER_MON: 0, TIMEOUT_DURATION: 0})
             );
+            IEngineHook[] memory hooks = new IEngineHook[](1);
+            hooks[0] = gachaRegistry;
             bytes32 battleKey =
-                _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, gachaRegistry);
+                _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, hooks);
 
             // Alice commits switching to mon index 0
             vm.startPrank(ALICE);
@@ -270,7 +274,9 @@ contract GachaTest is Test, BattleHelper {
         defaultRegistry.setTeam(BOB, team);
         vm.warp(gachaRegistry.BATTLE_COOLDOWN() + 1);
 
-        bytes32 battleKey = _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, gachaRegistry);
+        IEngineHook[] memory hooks = new IEngineHook[](1);
+        hooks[0] = gachaRegistry;
+        bytes32 battleKey = _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, hooks);
 
         // Magic number to trigger the bonus points after all the hashing we do
         bytes32 salt = keccak256(abi.encode(11));
@@ -317,7 +323,9 @@ contract GachaTest is Test, BattleHelper {
         defaultRegistry.setTeam(BOB, team);
         vm.warp(gachaRegistry.BATTLE_COOLDOWN() + 1);
 
-        bytes32 battleKey = _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, gachaRegistry);
+        IEngineHook[] memory hooks = new IEngineHook[](1);
+        hooks[0] = gachaRegistry;
+        bytes32 battleKey = _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, hooks);
 
         // Magic number to trigger the bonus points after all the hashing we do
         bytes32 salt = keccak256(abi.encode(11));
@@ -341,7 +349,8 @@ contract GachaTest is Test, BattleHelper {
         assertGt(bobPoints, 0);
 
         // Start another battle
-        battleKey = _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, gachaRegistry);
+        hooks[0] = gachaRegistry;
+        battleKey = _startBattle(validator, engine, defaultOracle, defaultRegistry, matchmaker, hooks);
         aliceMoveHash = keccak256(abi.encodePacked(SWITCH_MOVE_INDEX, salt, abi.encode(0)));
         vm.startPrank(ALICE);
         commitManager.commitMove(battleKey, aliceMoveHash);

--- a/test/MatchmakerTest.sol
+++ b/test/MatchmakerTest.sol
@@ -92,7 +92,7 @@ contract MatchmakerTest is Test {
             validator: validator,
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: IMoveManager(address(0)),
             matchmaker: matchmaker
         });
@@ -120,7 +120,7 @@ contract MatchmakerTest is Test {
             validator: validator,
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: IMoveManager(address(0)),
             matchmaker: matchmaker
         });
@@ -148,7 +148,7 @@ contract MatchmakerTest is Test {
             validator: validator,
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: IMoveManager(address(0)),
             matchmaker: matchmaker
         });
@@ -179,7 +179,7 @@ contract MatchmakerTest is Test {
             validator: validator,
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: IMoveManager(address(0)),
             matchmaker: matchmaker
         });
@@ -214,7 +214,7 @@ contract MatchmakerTest is Test {
             validator: validator,
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: IMoveManager(address(0)),
             matchmaker: matchmaker
         });
@@ -247,7 +247,7 @@ contract MatchmakerTest is Test {
             validator: validator,
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: IMoveManager(address(0)),
             matchmaker: matchmaker
         });
@@ -283,7 +283,7 @@ contract MatchmakerTest is Test {
             validator: validator,
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: IMoveManager(address(0)),
             matchmaker: matchmaker
         });
@@ -313,7 +313,7 @@ contract MatchmakerTest is Test {
             validator: validator,
             rngOracle: defaultOracle,
             ruleset: IRuleset(address(0)),
-            engineHook: IEngineHook(address(0)),
+            engineHooks: new IEngineHook[](0),
             moveManager: IMoveManager(address(0)),
             matchmaker: matchmaker
         });

--- a/test/abstract/BattleHelper.sol
+++ b/test/abstract/BattleHelper.sol
@@ -67,19 +67,6 @@ abstract contract BattleHelper is Test {
         IRandomnessOracle rngOracle,
         ITeamRegistry defaultRegistry,
         DefaultMatchmaker matchmaker,
-        IEngineHook engineHook
-    ) internal returns (bytes32) {
-        IEngineHook[] memory hooks = new IEngineHook[](1);
-        hooks[0] = engineHook;
-        return _startBattle(validator, engine, rngOracle, defaultRegistry, matchmaker, hooks);
-    }
-
-    function _startBattle(
-        IValidator validator,
-        Engine engine,
-        IRandomnessOracle rngOracle,
-        ITeamRegistry defaultRegistry,
-        DefaultMatchmaker matchmaker,
         IEngineHook[] memory engineHooks
     ) internal returns (bytes32) {
         return _startBattle(validator, engine, rngOracle, defaultRegistry, matchmaker, engineHooks, IRuleset(address(0)));

--- a/test/abstract/BattleHelper.sol
+++ b/test/abstract/BattleHelper.sol
@@ -58,7 +58,7 @@ abstract contract BattleHelper is Test {
         ITeamRegistry defaultRegistry,
         DefaultMatchmaker matchmaker
     ) internal returns (bytes32) {
-        return _startBattle(validator, engine, rngOracle, defaultRegistry, matchmaker, IEngineHook(address(0)));
+        return _startBattle(validator, engine, rngOracle, defaultRegistry, matchmaker, new IEngineHook[](0));
     }
 
     function _startBattle(
@@ -67,9 +67,9 @@ abstract contract BattleHelper is Test {
         IRandomnessOracle rngOracle,
         ITeamRegistry defaultRegistry,
         DefaultMatchmaker matchmaker,
-        IEngineHook engineHook
+        IEngineHook[] memory engineHooks
     ) internal returns (bytes32) {
-        return _startBattle(validator, engine, rngOracle, defaultRegistry, matchmaker, engineHook, IRuleset(address(0)));
+        return _startBattle(validator, engine, rngOracle, defaultRegistry, matchmaker, engineHooks, IRuleset(address(0)));
     }
 
     function _startBattle(
@@ -78,11 +78,11 @@ abstract contract BattleHelper is Test {
         IRandomnessOracle rngOracle,
         ITeamRegistry defaultRegistry,
         DefaultMatchmaker matchmaker,
-        IEngineHook engineHook,
+        IEngineHook[] memory engineHooks,
         IRuleset ruleset
     ) internal returns (bytes32) {
         return _startBattle(
-            validator, engine, rngOracle, defaultRegistry, matchmaker, engineHook, ruleset, IMoveManager(address(0))
+            validator, engine, rngOracle, defaultRegistry, matchmaker, engineHooks, ruleset, IMoveManager(address(0))
         );
     }
 
@@ -92,7 +92,7 @@ abstract contract BattleHelper is Test {
         IRandomnessOracle rngOracle,
         ITeamRegistry defaultRegistry,
         DefaultMatchmaker matchmaker,
-        IEngineHook engineHook,
+        IEngineHook[] memory engineHooks,
         IRuleset ruleset,
         IMoveManager moveManager
     ) internal returns (bytes32) {
@@ -123,7 +123,7 @@ abstract contract BattleHelper is Test {
             validator: validator,
             rngOracle: rngOracle,
             ruleset: ruleset,
-            engineHook: engineHook,
+            engineHooks: engineHooks,
             moveManager: moveManager,
             matchmaker: matchmaker
         });

--- a/test/abstract/BattleHelper.sol
+++ b/test/abstract/BattleHelper.sol
@@ -67,6 +67,19 @@ abstract contract BattleHelper is Test {
         IRandomnessOracle rngOracle,
         ITeamRegistry defaultRegistry,
         DefaultMatchmaker matchmaker,
+        IEngineHook engineHook
+    ) internal returns (bytes32) {
+        IEngineHook[] memory hooks = new IEngineHook[](1);
+        hooks[0] = engineHook;
+        return _startBattle(validator, engine, rngOracle, defaultRegistry, matchmaker, hooks);
+    }
+
+    function _startBattle(
+        IValidator validator,
+        Engine engine,
+        IRandomnessOracle rngOracle,
+        ITeamRegistry defaultRegistry,
+        DefaultMatchmaker matchmaker,
         IEngineHook[] memory engineHooks
     ) internal returns (bytes32) {
         return _startBattle(validator, engine, rngOracle, defaultRegistry, matchmaker, engineHooks, IRuleset(address(0)));

--- a/test/effects/EffectTest.sol
+++ b/test/effects/EffectTest.sol
@@ -758,7 +758,7 @@ contract EffectTest is Test, BattleHelper {
         defaultRegistry.setTeam(BOB, team);
 
         bytes32 battleKey = _startBattle(
-            oneMonOneMoveValidator, engine, mockOracle, defaultRegistry, matchmaker, IEngineHook(address(0)), rules
+            oneMonOneMoveValidator, engine, mockOracle, defaultRegistry, matchmaker, new IEngineHook[](0), rules
         );
 
         // First move of the game has to be selecting their mons (both index 0)


### PR DESCRIPTION
This change enables multiple active engine hooks per battle, providing greater flexibility for battle lifecycle management.

Changes:
- Updated Battle and ProposedBattle structs to use IEngineHook[] engineHooks
- Modified Engine.sol to iterate through all hooks when calling lifecycle methods:
  * onBattleStart (Engine.sol:155-159)
  * onRoundStart (Engine.sol:187-191)
  * onRoundEnd (Engine.sol:382-386)
  * onBattleEnd (Engine.sol:372-376, 403-407)
- Updated DefaultMatchmaker.sol to hash engineHooks array in battle integrity hash
- Updated CPU.sol battle struct initialization
- Updated all test files to use engineHooks arrays:
  * BattleHelper.sol: Updated helper function signatures
  * EngineTest.sol, CPUTest.sol, MatchmakerTest.sol, EffectTest.sol: Updated test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)