### PR TITLE
Refactor calculateValidMoves to return structured move types

### DIFF
--- a/src/cpu/CPU.sol
+++ b/src/cpu/CPU.sol
@@ -45,7 +45,7 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
      */
     function calculateValidMoves(bytes32 battleKey, uint256 playerIndex)
         public
-        returns (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp)
+        returns (RevealedMove[] memory noOp, RevealedMove[] memory moves, RevealedMove[] memory switches)
     {
         uint256 turnId = ENGINE.getTurnIdForBattleState(battleKey);
         uint256 nonce = nonceToUse;
@@ -56,7 +56,7 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
                 switchChoices[i] = RevealedMove({moveIndex: SWITCH_MOVE_INDEX, salt: "", extraData: abi.encode(i)});
             }
             nonceToUse = nonce;
-            return (new RevealedMove[](0), switchChoices, new RevealedMove[](0));
+            return (new RevealedMove[](0), new RevealedMove[](0), switchChoices);
         } else {
             Battle memory battle = ENGINE.getBattle(battleKey);
             uint256[] memory validSwitchIndices;
@@ -86,7 +86,7 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
                         });
                     }
                     nonceToUse = nonce;
-                    return (new RevealedMove[](0), switchChoices, new RevealedMove[](0));
+                    return (new RevealedMove[](0), new RevealedMove[](0), switchChoices);
                 }
             }
             uint256[] memory validMoveIndices;
@@ -132,7 +132,7 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
             noOpArray[0] = RevealedMove({moveIndex: NO_OP_MOVE_INDEX, salt: "", extraData: ""});
 
             nonceToUse = nonce;
-            return (validMovesArray, validSwitchesArray, noOpArray);
+            return (noOpArray, validMovesArray, validSwitchesArray);
         }
     }
 

--- a/src/cpu/CPU.sol
+++ b/src/cpu/CPU.sol
@@ -40,12 +40,12 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
         returns (uint256 moveIndex, bytes memory extraData);
 
     /**
-     *  - If it's a switch needed turn, returns [VALID SWITCHES]
-     *  - If it's a non-switch turn, returns [NO_OP | VALID MOVES | VALID SWITCHES]
+     *  - If it's a switch needed turn, returns only valid switches
+     *  - If it's a non-switch turn, returns valid moves, valid switches, and no-op separately
      */
     function calculateValidMoves(bytes32 battleKey, uint256 playerIndex)
         public
-        returns (RevealedMove[] memory, uint256 updatedNonce)
+        returns (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp)
     {
         uint256 turnId = ENGINE.getTurnIdForBattleState(battleKey);
         uint256 nonce = nonceToUse;
@@ -55,12 +55,12 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
             for (uint256 i = 0; i < teamSize; i++) {
                 switchChoices[i] = RevealedMove({moveIndex: SWITCH_MOVE_INDEX, salt: "", extraData: abi.encode(i)});
             }
-            return (switchChoices, nonce);
+            nonceToUse = nonce;
+            return (new RevealedMove[](0), switchChoices, new RevealedMove[](0));
         } else {
             Battle memory battle = ENGINE.getBattle(battleKey);
             uint256[] memory validSwitchIndices;
             uint256 validSwitchCount;
-            uint256 validMoves = 1; // (We can always do a no op)
             // Check for valid switches
             {
                 uint256[] memory activeMonIndex = ENGINE.getActiveMonIndexForBattleState(battleKey);
@@ -74,9 +74,8 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
                         }
                     }
                 }
-                validMoves += validSwitchCount;
             }
-            // If it's a turn where we need to make a switch, then we should just return a valid switch immediately
+            // If it's a turn where we need to make a switch, then we should just return valid switches
             {
                 BattleState memory battleState = ENGINE.getBattleState(battleKey);
                 if (battleState.playerSwitchForTurnFlag == 1) {
@@ -86,7 +85,8 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
                             moveIndex: SWITCH_MOVE_INDEX, salt: "", extraData: abi.encode(validSwitchIndices[i])
                         });
                     }
-                    return (switchChoices, nonce);
+                    nonceToUse = nonce;
+                    return (new RevealedMove[](0), switchChoices, new RevealedMove[](0));
                 }
             }
             uint256[] memory validMoveIndices;
@@ -115,20 +115,24 @@ abstract contract CPU is ICPU, ICPURNG, IMatchmaker {
                         validMoveIndices[validMoveCount++] = i;
                     }
                 }
-                validMoves += validMoveCount;
             }
-            RevealedMove[] memory moveChoices = new RevealedMove[](validMoves);
-            moveChoices[0] = RevealedMove({moveIndex: NO_OP_MOVE_INDEX, salt: "", extraData: ""});
+            // Build separate arrays for moves, switches, and noOp
+            RevealedMove[] memory validMovesArray = new RevealedMove[](validMoveCount);
+            for (uint256 i = 0; i < validMoveCount; i++) {
+                validMovesArray[i] =
+                    RevealedMove({moveIndex: validMoveIndices[i], salt: "", extraData: validMoveExtraData[i]});
+            }
+            RevealedMove[] memory validSwitchesArray = new RevealedMove[](validSwitchCount);
             for (uint256 i = 0; i < validSwitchCount; i++) {
-                moveChoices[i + 1] = RevealedMove({
+                validSwitchesArray[i] = RevealedMove({
                     moveIndex: SWITCH_MOVE_INDEX, salt: "", extraData: abi.encode(validSwitchIndices[i])
                 });
             }
-            for (uint256 i = 0; i < validMoveCount; i++) {
-                moveChoices[i + validSwitchCount + 1] =
-                    RevealedMove({moveIndex: validMoveIndices[i], salt: "", extraData: validMoveExtraData[i]});
-            }
-            return (moveChoices, nonce);
+            RevealedMove[] memory noOpArray = new RevealedMove[](1);
+            noOpArray[0] = RevealedMove({moveIndex: NO_OP_MOVE_INDEX, salt: "", extraData: ""});
+
+            nonceToUse = nonce;
+            return (validMovesArray, validSwitchesArray, noOpArray);
         }
     }
 

--- a/src/cpu/OkayCPU.sol
+++ b/src/cpu/OkayCPU.sol
@@ -20,21 +20,21 @@ contract OkayCPU is CPU {
         override
         returns (uint256 moveIndex, bytes memory extraData)
     {
-        (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = calculateValidMoves(battleKey, playerIndex);
+        (RevealedMove[] memory noOp, RevealedMove[] memory moves, RevealedMove[] memory switches) = calculateValidMoves(battleKey, playerIndex);
 
         // Merge all three arrays into one
-        uint256 totalChoices = moves.length + switches.length + noOp.length;
+        uint256 totalChoices = noOp.length + moves.length + switches.length;
         RevealedMove[] memory allChoices = new RevealedMove[](totalChoices);
 
         uint256 index = 0;
+        for (uint256 i = 0; i < noOp.length; i++) {
+            allChoices[index++] = noOp[i];
+        }
         for (uint256 i = 0; i < moves.length; i++) {
             allChoices[index++] = moves[i];
         }
         for (uint256 i = 0; i < switches.length; i++) {
             allChoices[index++] = switches[i];
-        }
-        for (uint256 i = 0; i < noOp.length; i++) {
-            allChoices[index++] = noOp[i];
         }
 
         // Select a random move from all choices

--- a/src/cpu/OkayCPU.sol
+++ b/src/cpu/OkayCPU.sol
@@ -20,11 +20,26 @@ contract OkayCPU is CPU {
         override
         returns (uint256 moveIndex, bytes memory extraData)
     {
-        (RevealedMove[] memory moveChoices, uint256 updatedNonce) = calculateValidMoves(battleKey, playerIndex);
+        (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = calculateValidMoves(battleKey, playerIndex);
 
-        nonceToUse = updatedNonce;
+        // Merge all three arrays into one
+        uint256 totalChoices = moves.length + switches.length + noOp.length;
+        RevealedMove[] memory allChoices = new RevealedMove[](totalChoices);
+
+        uint256 index = 0;
+        for (uint256 i = 0; i < moves.length; i++) {
+            allChoices[index++] = moves[i];
+        }
+        for (uint256 i = 0; i < switches.length; i++) {
+            allChoices[index++] = switches[i];
+        }
+        for (uint256 i = 0; i < noOp.length; i++) {
+            allChoices[index++] = noOp[i];
+        }
+
+        // Select a random move from all choices
         uint256 randomIndex =
-            RNG.getRNG(keccak256(abi.encode(nonceToUse++, battleKey, block.timestamp))) % moveChoices.length;
-        return (moveChoices[randomIndex].moveIndex, moveChoices[randomIndex].extraData);
+            RNG.getRNG(keccak256(abi.encode(nonceToUse++, battleKey, block.timestamp))) % allChoices.length;
+        return (allChoices[randomIndex].moveIndex, allChoices[randomIndex].extraData);
     }
 }

--- a/src/cpu/RandomCPU.sol
+++ b/src/cpu/RandomCPU.sol
@@ -20,21 +20,21 @@ contract RandomCPU is CPU {
         override
         returns (uint256 moveIndex, bytes memory extraData)
     {
-        (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = calculateValidMoves(battleKey, playerIndex);
+        (RevealedMove[] memory noOp, RevealedMove[] memory moves, RevealedMove[] memory switches) = calculateValidMoves(battleKey, playerIndex);
 
         // Merge all three arrays into one
-        uint256 totalChoices = moves.length + switches.length + noOp.length;
+        uint256 totalChoices = noOp.length + moves.length + switches.length;
         RevealedMove[] memory allChoices = new RevealedMove[](totalChoices);
 
         uint256 index = 0;
+        for (uint256 i = 0; i < noOp.length; i++) {
+            allChoices[index++] = noOp[i];
+        }
         for (uint256 i = 0; i < moves.length; i++) {
             allChoices[index++] = moves[i];
         }
         for (uint256 i = 0; i < switches.length; i++) {
             allChoices[index++] = switches[i];
-        }
-        for (uint256 i = 0; i < noOp.length; i++) {
-            allChoices[index++] = noOp[i];
         }
 
         // Select a random move from all choices

--- a/src/cpu/RandomCPU.sol
+++ b/src/cpu/RandomCPU.sol
@@ -20,10 +20,26 @@ contract RandomCPU is CPU {
         override
         returns (uint256 moveIndex, bytes memory extraData)
     {
-        (RevealedMove[] memory moveChoices, uint256 updatedNonce) = calculateValidMoves(battleKey, playerIndex);
-        nonceToUse = updatedNonce;
+        (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = calculateValidMoves(battleKey, playerIndex);
+
+        // Merge all three arrays into one
+        uint256 totalChoices = moves.length + switches.length + noOp.length;
+        RevealedMove[] memory allChoices = new RevealedMove[](totalChoices);
+
+        uint256 index = 0;
+        for (uint256 i = 0; i < moves.length; i++) {
+            allChoices[index++] = moves[i];
+        }
+        for (uint256 i = 0; i < switches.length; i++) {
+            allChoices[index++] = switches[i];
+        }
+        for (uint256 i = 0; i < noOp.length; i++) {
+            allChoices[index++] = noOp[i];
+        }
+
+        // Select a random move from all choices
         uint256 randomIndex =
-            RNG.getRNG(keccak256(abi.encode(nonceToUse++, battleKey, block.timestamp))) % moveChoices.length;
-        return (moveChoices[randomIndex].moveIndex, moveChoices[randomIndex].extraData);
+            RNG.getRNG(keccak256(abi.encode(nonceToUse++, battleKey, block.timestamp))) % allChoices.length;
+        return (allChoices[randomIndex].moveIndex, allChoices[randomIndex].extraData);
     }
 }

--- a/test/CPUTest.sol
+++ b/test/CPUTest.sol
@@ -216,8 +216,8 @@ contract CPUTest is Test {
 
         // Check that the CPU enumerates mon indices 0 to 4
         {
-            (RevealedMove[] memory moves,) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length, 4);
+            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(moves.length + switches.length + noOp.length, 4);
         }
 
         // Alice selects mon 2, CPU selects mon 1
@@ -230,8 +230,8 @@ contract CPUTest is Test {
 
         // Check that the CPU now has 6 moves (can swap to any one of the other 3 mons, 2 valid moves, and a no op)
         {
-            (RevealedMove[] memory moves,) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length, 6);
+            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(moves.length + switches.length + noOp.length, 6);
         }
 
         // Alice KO's the CPU's mon, the CPU chooses no op
@@ -240,15 +240,15 @@ contract CPUTest is Test {
 
         // Check that the CPU now has 3 moves, all of which are switching to mon index 0, 2, or 3
         {
-            (RevealedMove[] memory moves,) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length, 3);
+            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(moves.length + switches.length + noOp.length, 3);
             uint256[] memory swapIds = new uint256[](3);
             swapIds[0] = 0;
             swapIds[1] = 2;
             swapIds[2] = 3;
             for (uint256 i = 0; i < swapIds.length; i++) {
-                assertEq(moves[i].moveIndex, SWITCH_MOVE_INDEX);
-                assertEq(abi.decode(moves[i].extraData, (uint256)), swapIds[i]);
+                assertEq(switches[i].moveIndex, SWITCH_MOVE_INDEX);
+                assertEq(abi.decode(switches[i].extraData, (uint256)), swapIds[i]);
             }
         }
 
@@ -260,24 +260,24 @@ contract CPUTest is Test {
 
         // Assert that there are now 5 moves, switching to mon index 2, 3, the two moves, and no op
         {
-            (RevealedMove[] memory moves,) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length, 5);
+            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(moves.length + switches.length + noOp.length, 5);
         }
 
         // Alice chooses no op, CPU chooses move2 which should consume all stamina
-        mockCPURNG.setRNG(4); // [no op, swap 2, swap 3, move 1, move 2, ...] and we want move 2
+        mockCPURNG.setRNG(1); // [move 1, move 2, swap 2, swap 3, no op] and we want move 2
         // (note that the swaps are 0-indexed, and the moves are 1-indexed to refer to the above variable
         // naming convention, sorry D: )
         cpuMoveManager.selectMove(battleKey, NO_OP_MOVE_INDEX, "", "");
 
         // Assert that there are now 3 moves, switching to mon index 2, 3, and no op (all stamina has been consumed)
         {
-            (RevealedMove[] memory moves,) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length, 3);
+            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(moves.length + switches.length + noOp.length, 3);
         }
 
         // Alice chooses no op, CPU chooses swapping to mon index 3
-        mockCPURNG.setRNG(2); // [no op, swap 2, swap 3 and we want swap 3
+        mockCPURNG.setRNG(1); // [swap 2, swap 3, no op] and we want swap 3
         cpuMoveManager.selectMove(battleKey, NO_OP_MOVE_INDEX, "", "");
 
         // Assert the CPU now has mon index 3 as the active mon
@@ -286,10 +286,10 @@ contract CPUTest is Test {
         // Assert that there are now 4 moves, switching to mon index 0, 2, the two moves, and no op
         // Assert that both moves generate a valid self team index (either mon 0 or mon 2)
         {
-            (RevealedMove[] memory moves,) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length, 5);
-            assertEq(abi.decode(moves[3].extraData, (uint256)), 0); // rng is set to 2, which % 2 is 0
-            assertEq(abi.decode(moves[4].extraData, (uint256)), 0);
+            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(moves.length + switches.length + noOp.length, 5);
+            assertEq(abi.decode(moves[0].extraData, (uint256)), 0); // rng is set to 2, which % 2 is 0
+            assertEq(abi.decode(moves[1].extraData, (uint256)), 0);
         }
     }
 

--- a/test/CPUTest.sol
+++ b/test/CPUTest.sol
@@ -235,7 +235,7 @@ contract CPUTest is Test {
         }
 
         // Alice KO's the CPU's mon, the CPU chooses no op
-        mockCPURNG.setRNG(0);
+        mockCPURNG.setRNG(5); // [move 1, move 2, swap 0, swap 2, swap 3, no op] and we want no op at index 5
         cpuMoveManager.selectMove(battleKey, 0, "", "");
 
         // Check that the CPU now has 3 moves, all of which are switching to mon index 0, 2, or 3

--- a/test/CPUTest.sol
+++ b/test/CPUTest.sol
@@ -216,8 +216,8 @@ contract CPUTest is Test {
 
         // Check that the CPU enumerates mon indices 0 to 4
         {
-            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length + switches.length + noOp.length, 4);
+            (RevealedMove[] memory noOp, RevealedMove[] memory moves, RevealedMove[] memory switches) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(noOp.length + moves.length + switches.length, 4);
         }
 
         // Alice selects mon 2, CPU selects mon 1
@@ -230,18 +230,18 @@ contract CPUTest is Test {
 
         // Check that the CPU now has 6 moves (can swap to any one of the other 3 mons, 2 valid moves, and a no op)
         {
-            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length + switches.length + noOp.length, 6);
+            (RevealedMove[] memory noOp, RevealedMove[] memory moves, RevealedMove[] memory switches) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(noOp.length + moves.length + switches.length, 6);
         }
 
         // Alice KO's the CPU's mon, the CPU chooses no op
-        mockCPURNG.setRNG(5); // [move 1, move 2, swap 0, swap 2, swap 3, no op] and we want no op at index 5
+        mockCPURNG.setRNG(0); // [no op, move 1, move 2, swap 0, swap 2, swap 3] and we want no op at index 0
         cpuMoveManager.selectMove(battleKey, 0, "", "");
 
         // Check that the CPU now has 3 moves, all of which are switching to mon index 0, 2, or 3
         {
-            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length + switches.length + noOp.length, 3);
+            (RevealedMove[] memory noOp, RevealedMove[] memory moves, RevealedMove[] memory switches) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(noOp.length + moves.length + switches.length, 3);
             uint256[] memory swapIds = new uint256[](3);
             swapIds[0] = 0;
             swapIds[1] = 2;
@@ -260,24 +260,24 @@ contract CPUTest is Test {
 
         // Assert that there are now 5 moves, switching to mon index 2, 3, the two moves, and no op
         {
-            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length + switches.length + noOp.length, 5);
+            (RevealedMove[] memory noOp, RevealedMove[] memory moves, RevealedMove[] memory switches) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(noOp.length + moves.length + switches.length, 5);
         }
 
         // Alice chooses no op, CPU chooses move2 which should consume all stamina
-        mockCPURNG.setRNG(1); // [move 1, move 2, swap 2, swap 3, no op] and we want move 2
+        mockCPURNG.setRNG(2); // [no op, move 1, move 2, swap 2, swap 3] and we want move 2 at index 2
         // (note that the swaps are 0-indexed, and the moves are 1-indexed to refer to the above variable
         // naming convention, sorry D: )
         cpuMoveManager.selectMove(battleKey, NO_OP_MOVE_INDEX, "", "");
 
         // Assert that there are now 3 moves, switching to mon index 2, 3, and no op (all stamina has been consumed)
         {
-            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length + switches.length + noOp.length, 3);
+            (RevealedMove[] memory noOp, RevealedMove[] memory moves, RevealedMove[] memory switches) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(noOp.length + moves.length + switches.length, 3);
         }
 
         // Alice chooses no op, CPU chooses swapping to mon index 3
-        mockCPURNG.setRNG(1); // [swap 2, swap 3, no op] and we want swap 3
+        mockCPURNG.setRNG(2); // [no op, swap 2, swap 3] and we want swap 3 at index 2
         cpuMoveManager.selectMove(battleKey, NO_OP_MOVE_INDEX, "", "");
 
         // Assert the CPU now has mon index 3 as the active mon
@@ -286,8 +286,8 @@ contract CPUTest is Test {
         // Assert that there are now 4 moves, switching to mon index 0, 2, the two moves, and no op
         // Assert that both moves generate a valid self team index (either mon 0 or mon 2)
         {
-            (RevealedMove[] memory moves, RevealedMove[] memory switches, RevealedMove[] memory noOp) = cpu.calculateValidMoves(battleKey, 1);
-            assertEq(moves.length + switches.length + noOp.length, 5);
+            (RevealedMove[] memory noOp, RevealedMove[] memory moves, RevealedMove[] memory switches) = cpu.calculateValidMoves(battleKey, 1);
+            assertEq(noOp.length + moves.length + switches.length, 5);
             assertEq(abi.decode(moves[0].extraData, (uint256)), 0); // rng is set to 2, which % 2 is 0
             assertEq(abi.decode(moves[1].extraData, (uint256)), 0);
         }


### PR DESCRIPTION
Changed the function signature from returning a single array of moves to returning three separate arrays (moves, switches, noOp). This makes it easier to write new CPU contracts that can perform smarter calculations based on move types.

Changes:
- CPU.sol: Return (moves, switches, noOp) instead of (allMoves, nonce)
- RandomCPU.sol: Merge arrays and select randomly
- OkayCPU.sol: Merge arrays and select randomly
- CPUTest.sol: Update tests to use new signature

The nonce is now updated directly in calculateValidMoves rather than being returned, simplifying the interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)