### PR TITLE
Refactor battle state winner tracking

### DIFF
--- a/src/Engine.sol
+++ b/src/Engine.sol
@@ -170,6 +170,9 @@ contract Engine is IEngine, MappingAllocator {
         // Set flag to be 2 which means both players act
         battleStates[battleKey].playerSwitchForTurnFlag = 2;
 
+        // Initialize winnerIndex to 2 (uninitialized/no winner)
+        battleStates[battleKey].winnerIndex = 2;
+
         for (uint256 i = 0; i < battle.engineHooks.length; i++) {
             battle.engineHooks[i].onBattleStart(battleKey);
         }

--- a/src/Structs.sol
+++ b/src/Structs.sol
@@ -62,7 +62,7 @@ struct BattleConfig {
 
 // Stored by the Engine for a battle, tracks mutable battle data
 struct BattleState {
-    address winner;
+    uint8 winnerIndex; // 2 = uninitialized (no winner), 0 = p0 winner, 1 = p1 winner
     uint64 turnId;
     uint8 prevPlayerSwitchForTurnFlag;
     uint8 playerSwitchForTurnFlag;

--- a/src/cpu/CPUMoveManager.sol
+++ b/src/cpu/CPUMoveManager.sol
@@ -29,7 +29,7 @@ contract CPUMoveManager is IMoveManager {
         }
 
         BattleState memory battleState = ENGINE.getBattleState(battleKey);
-        if (battleState.winner != address(0)) {
+        if (battleState.winnerIndex != 2) {
             return;
         }
 

--- a/src/hooks/BattleHistory.sol
+++ b/src/hooks/BattleHistory.sol
@@ -40,11 +40,10 @@ contract BattleHistory is IEngineHook {
     /// @notice Called when a battle ends - updates battle statistics
     function onBattleEnd(bytes32 battleKey) external {
         (, BattleData memory battleData) = engine.getBattle(battleKey);
-        BattleState memory battleState = engine.getBattleState(battleKey);
 
         address p0 = battleData.p0;
         address p1 = battleData.p1;
-        address winner = battleState.winner;
+        address winner = engine.getWinner(battleKey);
 
         // Update total battles for both players
         _numBattles[p0]++;

--- a/test/BattleHistoryTest.sol
+++ b/test/BattleHistoryTest.sol
@@ -227,7 +227,7 @@ contract BattleHistoryTest is Test, BattleHelper {
 
         // Verify winner
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, ALICE, "Alice should be the winner");
+        assertEq(engine.getWinner(battleKey), ALICE, "Alice should be the winner");
     }
 
     function test_GetNumBattlesTracksCorrectly() public {

--- a/test/EngineTest.sol
+++ b/test/EngineTest.sol
@@ -193,7 +193,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert Alice wins
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, ALICE);
+        assertEq(engine.getWinner(battleKey), ALICE);
 
         // Assert that the staminaDelta was set correctly
         assertEq(state.monStates[0][0].staminaDelta, -1);
@@ -268,7 +268,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert Bob wins as he has faster priority on a slower mon
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, BOB);
+        assertEq(engine.getWinner(battleKey), BOB);
 
         // Assert that the staminaDelta was set correctly for Bob's mon
         assertEq(state.monStates[1][0].staminaDelta, -1);
@@ -376,7 +376,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert Bob wins as he has faster priority on a slower mon
         state = engine.getBattleState(battleKey);
-        assertEq(state.winner, BOB);
+        assertEq(engine.getWinner(battleKey), BOB);
 
         // Assert that the staminaDelta was set correctly for Bob's mon
         // (we used two attacks of 1 stamina, so -2)
@@ -406,7 +406,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert Bob wins
         state = engine.getBattleState(battleKey);
-        assertEq(state.winner, BOB);
+        assertEq(engine.getWinner(battleKey), BOB);
     }
 
     function test_fasterPriorityKOsForcesSwitchCorrectlyFailsOnInvalidSwitchNoCommit() public {
@@ -428,7 +428,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert Bob wins
         state = engine.getBattleState(battleKey);
-        assertEq(state.winner, BOB);
+        assertEq(engine.getWinner(battleKey), BOB);
     }
 
     function test_nonKOSubsequentMoves() public {
@@ -482,9 +482,9 @@ contract EngineTest is Test, BattleHelper {
         uint256 finalRNG = state.rng;
         uint256 winnerIndex = finalRNG % 2;
         if (winnerIndex == 0) {
-            assertEq(state.winner, ALICE);
+            assertEq(engine.getWinner(battleKey), ALICE);
         } else {
-            assertEq(state.winner, BOB);
+            assertEq(engine.getWinner(battleKey), BOB);
         }
 
         // Assert that the staminaDelta was set correctly (2 moves spent) for the winning mon
@@ -965,7 +965,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert Bob wins
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, BOB);
+        assertEq(engine.getWinner(battleKey), BOB);
     }
 
     function test_effectAppliedByAttackCanKOAndForceSwitch() public {
@@ -1179,7 +1179,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert Alice wins
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, ALICE);
+        assertEq(engine.getWinner(battleKey), ALICE);
     }
 
     function test_moveKOAndEffectKOLeadToDualSwapOtherMoveRevertsForAlice() public {
@@ -1431,7 +1431,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert no winner, and no damage dealt
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, address(0));
+        assertEq(engine.getWinner(battleKey), address(0));
         assertEq(state.monStates[1][0].hpDelta, 0);
     }
 
@@ -2073,7 +2073,7 @@ contract EngineTest is Test, BattleHelper {
         // After this, Alice's mon should be dead and Bob should be the winner
         // Verify Bob is the winner
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, BOB);
+        assertEq(engine.getWinner(battleKey), BOB);
     }
 
     // ability triggers effect leading to death on self after being switched in from self move
@@ -2609,7 +2609,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Check that ALICE wins (Bob didn't commit for round 2)
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, ALICE);
+        assertEq(engine.getWinner(battleKey), ALICE);
 
         // // Bob should not be able to commit to the ended battle
         vm.startPrank(BOB);
@@ -2896,7 +2896,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert that Bob wins bc Alice didn't commit to start
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, BOB);
+        assertEq(engine.getWinner(battleKey), BOB);
     }
 
     function test_timeoutSucceedsRevealPlayerNoSwitchFlag() public {
@@ -2917,7 +2917,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert that Alice wins because Bob didn't reveal
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, ALICE);
+        assertEq(engine.getWinner(battleKey), ALICE);
     }
 
     function test_timeoutSucceedsCommitPlayerWitholdsRevealNoSwitchFlag() public {
@@ -2942,7 +2942,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert that Bob wins because Alice didn't reveal
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, BOB);
+        assertEq(engine.getWinner(battleKey), BOB);
     }
 
     function test_timeoutScceedsRevealPlayerSwitchFlag() public {
@@ -3017,7 +3017,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Assert that Alice wins because Bob didn't reveal
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, ALICE);
+        assertEq(engine.getWinner(battleKey), ALICE);
     }
 
     function test_secondBattleDifferentBattleKey() public {

--- a/test/GachaTest.sol
+++ b/test/GachaTest.sol
@@ -135,7 +135,7 @@ contract GachaTest is Test, BattleHelper {
 
         // Assert Alice won
         BattleState memory state = engine.getBattleState(battleKey);
-        assertEq(state.winner, ALICE);
+        assertEq(engine.getWinner(battleKey), ALICE);
 
         // Verify points are correct
         assertEq(gachaRegistry.pointsBalance(ALICE), gachaRegistry.POINTS_PER_WIN());


### PR DESCRIPTION
Changes:
- Replace `address winner` with `uint8 winnerIndex` in BattleState struct
- winnerIndex values: 2 = uninitialized (no winner), 0 = p0 winner, 1 = p1 winner
- Update Engine.sol to use winnerIndex internally for all checks and assignments
- Maintain getWinner() interface - converts winnerIndex back to address for external callers
- Update BattleHistory hook to use engine.getWinner() instead of accessing state.winner directly
- Update all test assertions to use engine.getWinner(battleKey) instead of state.winner

Benefits:
- Reduces storage cost by using uint8 instead of address (1 byte vs 20 bytes)
- Enables better struct packing in BattleState
- Maintains backwards compatibility through getWinner() interface