### PR TITLE
Add OnUpdateMonState Effect lifecycle hook

### DIFF
--- a/src/Enums.sol
+++ b/src/Enums.sol
@@ -33,7 +33,8 @@ enum EffectStep {
     OnMonSwitchIn,
     OnMonSwitchOut,
     AfterDamage,
-    AfterMove
+    AfterMove,
+    OnUpdateMonState
 }
 
 enum MoveClass {

--- a/src/effects/BasicEffect.sol
+++ b/src/effects/BasicEffect.sol
@@ -69,6 +69,16 @@ abstract contract BasicEffect is IEffect {
         return (extraData, false);
     }
 
+    // NOTE: CURRENTLY ONLY RUN LOCALLY ON MONS (global effects do not have this hook)
+    // WARNING: Avoid chaining this effect to prevent recursive calls
+    function onUpdateMonState(uint256, bytes memory extraData, uint256, uint256, MonStateIndexName, int32)
+        external
+        virtual
+        returns (bytes memory updatedExtraData, bool removeAfterRun)
+    {
+        return (extraData, false);
+    }
+
     // Lifecycle hooks when being applied or removed
     function onApply(uint256, bytes memory, uint256, uint256)
         external

--- a/src/effects/IEffect.sol
+++ b/src/effects/IEffect.sol
@@ -39,6 +39,18 @@ interface IEffect {
         external
         returns (bytes memory updatedExtraData, bool removeAfterRun);
 
+    // NOTE: CURRENTLY ONLY RUN LOCALLY ON MONS (global effects do not have this hook)
+    // WARNING: Avoid chaining this effect to prevent recursive calls
+    // (e.g., an effect that mutates state triggering another effect that mutates state)
+    function onUpdateMonState(
+        uint256 rng,
+        bytes memory extraData,
+        uint256 playerIndex,
+        uint256 monIndex,
+        MonStateIndexName stateVarIndex,
+        int32 valueToAdd
+    ) external returns (bytes memory updatedExtraData, bool removeAfterRun);
+
     // Lifecycle hooks when being applied or removed
     function onApply(uint256 rng, bytes memory extraData, uint256 targetIndex, uint256 monIndex)
         external

--- a/test/mocks/OnUpdateMonStateHealEffect.sol
+++ b/test/mocks/OnUpdateMonStateHealEffect.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity ^0.8.0;
+
+import "../../src/Enums.sol";
+import "../../src/Structs.sol";
+
+import {IEngine} from "../../src/IEngine.sol";
+import {BasicEffect} from "../../src/effects/BasicEffect.sol";
+
+/**
+ * @title OnUpdateMonStateHealEffect
+ * @notice Mock effect that heals a mon's HP when its SpecialAttack stat is reduced
+ * @dev This demonstrates the OnUpdateMonState lifecycle hook
+ */
+contract OnUpdateMonStateHealEffect is BasicEffect {
+    IEngine immutable ENGINE;
+    int32 public constant HEAL_AMOUNT = 5;
+
+    constructor(IEngine _ENGINE) {
+        ENGINE = _ENGINE;
+    }
+
+    function shouldRunAtStep(EffectStep r) external pure override returns (bool) {
+        return r == EffectStep.OnUpdateMonState;
+    }
+
+    // WARNING: Avoid chaining this effect to prevent recursive calls
+    // This effect is safe because it only heals HP, it doesn't trigger state updates that would recurse
+    function onUpdateMonState(
+        uint256,
+        bytes memory extraData,
+        uint256 playerIndex,
+        uint256 monIndex,
+        MonStateIndexName stateVarIndex,
+        int32 valueToAdd
+    ) external override returns (bytes memory, bool) {
+        // Only trigger if SpecialAttack is being reduced (negative valueToAdd)
+        if (stateVarIndex == MonStateIndexName.SpecialAttack && valueToAdd < 0) {
+            // Heal the mon by HEAL_AMOUNT
+            ENGINE.updateMonState(playerIndex, monIndex, MonStateIndexName.Hp, HEAL_AMOUNT);
+        }
+        return (extraData, false);
+    }
+}

--- a/test/mocks/ReduceSpAtkMove.sol
+++ b/test/mocks/ReduceSpAtkMove.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity ^0.8.0;
+
+import "../../src/Constants.sol";
+import "../../src/Enums.sol";
+import "../../src/Structs.sol";
+
+import {IEngine} from "../../src/IEngine.sol";
+import {IMoveSet} from "../../src/moves/IMoveSet.sol";
+
+/**
+ * @title ReduceSpAtkMove
+ * @notice Simple move that reduces the opposing mon's SpecialAttack stat by 1
+ * @dev Used to test the OnUpdateMonState lifecycle hook
+ */
+contract ReduceSpAtkMove is IMoveSet {
+    IEngine immutable ENGINE;
+
+    constructor(IEngine _ENGINE) {
+        ENGINE = _ENGINE;
+    }
+
+    function name() external pure returns (string memory) {
+        return "Reduce SpAtk";
+    }
+
+    function move(bytes32, uint256 attackerPlayerIndex, bytes memory, uint256) external {
+        // Get the opposing player's index
+        uint256 opposingPlayerIndex = (attackerPlayerIndex + 1) % 2;
+
+        // Get the opposing player's active mon index
+        uint256 opposingMonIndex = ENGINE.getActiveMonIndex(ENGINE.battleKeyForWrite(), opposingPlayerIndex);
+
+        // Reduce the opposing mon's SpecialAttack by 1
+        ENGINE.updateMonState(opposingPlayerIndex, opposingMonIndex, MonStateIndexName.SpecialAttack, -1);
+    }
+
+    function priority(bytes32, uint256) external pure returns (uint32) {
+        return 0;
+    }
+
+    function stamina(bytes32, uint256, uint256) external pure returns (uint32) {
+        return 0;
+    }
+
+    function moveType(bytes32) external pure returns (Type) {
+        return Type.Mind;
+    }
+
+    function isValidTarget(bytes32, bytes calldata) external pure returns (bool) {
+        return true;
+    }
+
+    function moveClass(bytes32) external pure returns (MoveClass) {
+        return MoveClass.Other;
+    }
+
+    function basePower(bytes32) external pure returns (uint32) {
+        return 0;
+    }
+
+    function extraDataType() external pure returns (ExtraDataType) {
+        return ExtraDataType.None;
+    }
+}

--- a/test/mocks/ReduceSpAtkMove.sol
+++ b/test/mocks/ReduceSpAtkMove.sol
@@ -30,7 +30,7 @@ contract ReduceSpAtkMove is IMoveSet {
         uint256 opposingPlayerIndex = (attackerPlayerIndex + 1) % 2;
 
         // Get the opposing player's active mon index
-        uint256 opposingMonIndex = ENGINE.getActiveMonIndex(ENGINE.battleKeyForWrite(), opposingPlayerIndex);
+        uint256 opposingMonIndex = ENGINE.getActiveMonIndexForBattleState(ENGINE.battleKeyForWrite())[opposingPlayerIndex];
 
         // Reduce the opposing mon's SpecialAttack by 1
         ENGINE.updateMonState(opposingPlayerIndex, opposingMonIndex, MonStateIndexName.SpecialAttack, -1);


### PR DESCRIPTION
This commit implements a new Effect lifecycle hook called OnUpdateMonState that triggers when a mon's state is updated via updateMonState().

Changes:
- Added OnUpdateMonState to EffectStep enum
- Added onUpdateMonState hook to IEffect interface with warning comment about avoiding recursive calls
- Added default implementation in BasicEffect
- Added decoding logic in _runEffects to handle the hook
- Modified updateMonState to call _runEffects with encoded arguments (playerIndex, monIndex, stateVarIndex, valueToAdd)

Test additions:
- Created OnUpdateMonStateHealEffect mock that heals HP when SpATK is reduced
- Created ReduceSpAtkMove mock that reduces opposing mon's SpATK by 1
- Added test_onUpdateMonStateHook test in EffectTest to verify the hook triggers correctly when state changes

The implementation follows the same pattern as AfterDamage hook, encoding arguments and decoding them in _runEffects.