### PR TITLE
Refactor Engine.sol battle data mappings

### DIFF
--- a/src/IEngine.sol
+++ b/src/IEngine.sol
@@ -33,7 +33,6 @@ interface IEngine {
     function computePriorityPlayerIndex(bytes32 battleKey, uint256 rng) external view returns (uint256);
     function getMoveManager(bytes32 battleKey) external view returns (address);
     function getBattle(bytes32 battleKey) external view returns (BattleConfigView memory, BattleData memory);
-    function getBattleState(bytes32 battleKey) external view returns (BattleState memory);
     function getMonValueForBattle(
         bytes32 battleKey,
         uint256 playerIndex,

--- a/src/Structs.sol
+++ b/src/Structs.sol
@@ -49,10 +49,15 @@ struct MoveDecision {
     bytes extraData;
 }
 
-// Stored by the Engine, tracks immutable battle data
+// Stored by the Engine, tracks immutable battle data and battle state
 struct BattleData {
     address p1;
     address p0;
+    uint8 winnerIndex; // 2 = uninitialized (no winner), 0 = p0 winner, 1 = p1 winner
+    uint8 prevPlayerSwitchForTurnFlag;
+    uint8 playerSwitchForTurnFlag;
+    uint16 activeMonIndex; // Packed: lower 8 bits = player0, upper 8 bits = player1
+    uint64 turnId;
 }
 
 // Stored by the Engine for a battle, is overwritten after a battle is over

--- a/test/EngineGasTest.sol
+++ b/test/EngineGasTest.sol
@@ -467,7 +467,7 @@ contract EngineGasTest is Test, BattleHelper {
         uint256 execute1 = vm.stopSnapshotGas("B1_Execute");
 
         // Verify battle 1 ended
-        BattleState memory state1 = engine.getBattleState(battleKey1);
+        (, BattleData memory state1) = engine.getBattle(battleKey1);
         console.log("Battle 1 winner index:", state1.winnerIndex);
         assertTrue(state1.winnerIndex != 2, "Battle 1 should have ended");
 

--- a/test/EngineTest.sol
+++ b/test/EngineTest.sol
@@ -126,7 +126,7 @@ contract EngineTest is Test, BattleHelper {
         _commitRevealExecuteForAliceAndBob(engine, commitManager, battleKey, NO_OP_MOVE_INDEX, NO_OP_MOVE_INDEX, "", "");
 
         // Turn ID should now be 2
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.turnId, 2);
     }
 
@@ -355,7 +355,7 @@ contract EngineTest is Test, BattleHelper {
         bytes32 battleKey = _setup2v2FasterPriorityBattleAndForceSwitch();
 
         // Check that Alice (p0) now has the playerSwitch flag set
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 0);
 
         // Assert that Bob cannot commit anything because of the turn flag
@@ -384,7 +384,7 @@ contract EngineTest is Test, BattleHelper {
         bytes32 battleKey = _setup2v2FasterPriorityBattleAndForceSwitch();
 
         // Check that Alice (p0) now has the playerSwitch flag set
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 0);
 
         // Alice now switches (invalidly) to mon index 0
@@ -402,7 +402,7 @@ contract EngineTest is Test, BattleHelper {
         engine.end(battleKey);
 
         // Assert Bob wins
-        state = engine.getBattleState(battleKey);
+        (, state) = engine.getBattle(battleKey);
         assertEq(engine.getWinner(battleKey), BOB);
     }
 
@@ -410,7 +410,7 @@ contract EngineTest is Test, BattleHelper {
         bytes32 battleKey = _setup2v2FasterPriorityBattleAndForceSwitch();
 
         // Check that Alice (p0) now has the playerSwitch flag set
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 0);
 
         // Attempt to forcibly advance the game state
@@ -425,7 +425,7 @@ contract EngineTest is Test, BattleHelper {
         engine.end(battleKey);
 
         // Assert Bob wins
-        state = engine.getBattleState(battleKey);
+        (, state) = engine.getBattle(battleKey);
         assertEq(engine.getWinner(battleKey), BOB);
     }
 
@@ -476,7 +476,7 @@ contract EngineTest is Test, BattleHelper {
         _commitRevealExecuteForAliceAndBob(engine, commitManager, battleKey, 0, 0, "", "");
 
         // Both Alice and Bob's mons have the same speed, so the final priority player is rng % 2
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
 
         // Assert that the staminaDelta was set correctly (2 moves spent) for the winning mon
         assertEq(engine.getMonStateForStorageKey(battleKey, state.winnerIndex, 0, MonStateIndexName.Stamina), -2);
@@ -640,7 +640,7 @@ contract EngineTest is Test, BattleHelper {
 
         // Given that it's a KO (even though Alice chose switch),
         // check that now they have the priority flag again
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 0);
     }
 
@@ -1843,7 +1843,7 @@ contract EngineTest is Test, BattleHelper {
         _commitRevealExecuteForAliceAndBob(engine, commitManager, battleKey, 0, 0, abi.encode(0, 1), "");
 
         // Assert that the player switch for turn flag is now 0, indicating Alice has to switch
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 0);
 
         // Assert that Alice's new mon is now KOed
@@ -1913,7 +1913,7 @@ contract EngineTest is Test, BattleHelper {
         _commitRevealExecuteForAliceAndBob(engine, commitManager, battleKey, 0, 1, abi.encode(1, 1), "");
 
         // Assert that the player switch for turn flag is now 0, indicating Bob has to switch
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 1);
 
         // Assert that Bob's new mon is now KOed
@@ -1981,7 +1981,7 @@ contract EngineTest is Test, BattleHelper {
         _commitRevealExecuteForAliceAndBob(engine, commitManager, battleKey, SWITCH_MOVE_INDEX, 0, abi.encode(1), "");
 
         // Assert that the player switch for turn flag is now 0, indicating Alice has to switch
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 0);
 
         // Assert that Alice's new mon is now KOed
@@ -2150,7 +2150,7 @@ contract EngineTest is Test, BattleHelper {
         assertEq(engine.getMonStateForBattle(battleKey, 0, 1, MonStateIndexName.IsKnockedOut), 1);
 
         // Assert that player switch flag for turn is now 0, indicating Alice has to switch
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 0);
     }
 
@@ -2251,7 +2251,7 @@ contract EngineTest is Test, BattleHelper {
         assertEq(engine.getMonStateForBattle(battleKey, 0, 1, MonStateIndexName.IsKnockedOut), 1);
 
         // Assert that player switch flag for turn is now 0, indicating Alice has to switch
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 0);
     }
 
@@ -3021,7 +3021,7 @@ contract EngineTest is Test, BattleHelper {
         // Both players pick move index 0
         _commitRevealExecuteForAliceAndBob(battleKey, 0, 0, abi.encode(1), abi.encode(0));
         // Switch for turn flag should be 0, Bob's active mon index should now be 0
-        BattleState memory state = engine.getBattleState(battleKey);
+        (, BattleData memory state) = engine.getBattle(battleKey);
         assertEq(state.playerSwitchForTurnFlag, 0);
         assertEq(engine.getActiveMonIndexForBattleState(battleKey)[1], 0);
     }


### PR DESCRIPTION
- Merged BattleState fields into BattleData struct
- Removed battleStates mapping from Engine.sol
- Updated all references to battleStates to use battleData
- Removed getBattleState function from Engine.sol and IEngine
- Updated all tests to use getBattle instead of getBattleState

The BattleData struct now contains both immutable battle data (p0, p1) and battle state (winnerIndex, turnId, activeMonIndex, etc.)