### PR TITLE
Optimize storage costs across smart contracts

### DIFF
--- a/src/DefaultCommitManager.sol
+++ b/src/DefaultCommitManager.sol
@@ -231,21 +231,24 @@ contract DefaultCommitManager is ICommitManager {
     }
 
     function getCommitment(bytes32 battleKey, address player) external view returns (bytes32 moveHash, uint256 turnId) {
-        BattleContext memory ctx = ENGINE.getBattleContext(battleKey);
-        uint256 playerIndex = (player == ctx.p0) ? 0 : 1;
+        // Use lighter-weight getPlayersForBattle instead of getBattleContext (fewer SLOADs)
+        address[] memory players = ENGINE.getPlayersForBattle(battleKey);
+        uint256 playerIndex = (player == players[0]) ? 0 : 1;
         PlayerDecisionData storage pd = playerData[battleKey][playerIndex];
         return (pd.moveHash, pd.lastCommitmentTurnId);
     }
 
     function getMoveCountForBattleState(bytes32 battleKey, address player) external view returns (uint256) {
-        BattleContext memory ctx = ENGINE.getBattleContext(battleKey);
-        uint256 playerIndex = (player == ctx.p0) ? 0 : 1;
+        // Use lighter-weight getPlayersForBattle instead of getBattleContext (fewer SLOADs)
+        address[] memory players = ENGINE.getPlayersForBattle(battleKey);
+        uint256 playerIndex = (player == players[0]) ? 0 : 1;
         return playerData[battleKey][playerIndex].numMovesRevealed;
     }
 
     function getLastMoveTimestampForPlayer(bytes32 battleKey, address player) external view returns (uint256) {
-        BattleContext memory ctx = ENGINE.getBattleContext(battleKey);
-        uint256 playerIndex = (player == ctx.p0) ? 0 : 1;
+        // Use lighter-weight getPlayersForBattle instead of getBattleContext (fewer SLOADs)
+        address[] memory players = ENGINE.getPlayersForBattle(battleKey);
+        uint256 playerIndex = (player == players[0]) ? 0 : 1;
         return playerData[battleKey][playerIndex].lastMoveTimestamp;
     }
 }

--- a/src/Engine.sol
+++ b/src/Engine.sol
@@ -825,7 +825,11 @@ contract Engine is IEngine, MappingAllocator {
         // Use cached key if called during execute(), otherwise lookup
         bool isForCurrentBattle = battleKeyForWrite == battleKey;
         bytes32 storageKey = isForCurrentBattle ? storageKeyForWrite : _getStorageKey(battleKey);
-        bool isMoveManager = msg.sender == address(battleConfig[storageKey].moveManager);
+
+        // Cache storage pointer to avoid repeated mapping lookups
+        BattleConfig storage config = battleConfig[storageKey];
+
+        bool isMoveManager = msg.sender == address(config.moveManager);
         if (!isMoveManager && !isForCurrentBattle) {
             revert NoWriteAllowed();
         }
@@ -834,11 +838,11 @@ contract Engine is IEngine, MappingAllocator {
         MoveDecision memory newMove = MoveDecision({moveIndex: moveIndex, isRealTurn: 1, extraData: extraData});
 
         if (playerIndex == 0) {
-            battleConfig[storageKey].p0Move = newMove;
-            battleConfig[storageKey].p0Salt = salt;
+            config.p0Move = newMove;
+            config.p0Salt = salt;
         } else {
-            battleConfig[storageKey].p1Move = newMove;
-            battleConfig[storageKey].p1Salt = salt;
+            config.p1Move = newMove;
+            config.p1Salt = salt;
         }
     }
 


### PR DESCRIPTION
- StatBoosts: Combine _findExistingBoostWithKey and _recalculateAndApplyStats into single-pass functions for add/remove operations. Previously made 2 external calls to ENGINE.getEffects; now makes 1 call and computes aggregation in the same loop. Saves ~5,000-8,000 gas per stat boost op.

- Engine: Cache BattleConfig storage pointer in setMove() to avoid repeated mapping lookups for p0Move/p0Salt or p1Move/p1Salt. Saves ~200 gas.

- DefaultCommitManager: Use getPlayersForBattle() instead of getBattleContext() in view functions (getCommitment, getMoveCountForBattleState, getLastMoveTimestampForPlayer). getBattleContext loads many fields; getPlayersForBattle only loads p0/p1 addresses. Saves ~1,000 gas per call.