### PR TITLE
Refactor battle service to use BattleHarness abstraction

### DIFF
--- a/client/lib/metadata-converter.ts
+++ b/client/lib/metadata-converter.ts
@@ -74,20 +74,20 @@ export function resolveConstant(
     return value;
   }
 
-  // Constant references
+  // Constant references (constants are bigint from transpiled output)
   switch (value) {
     case 'DEFAULT_PRIORITY':
-      return DEFAULT_CONSTANTS.DEFAULT_PRIORITY;
+      return Number(DEFAULT_CONSTANTS.DEFAULT_PRIORITY);
     case 'DEFAULT_STAMINA':
-      return DEFAULT_CONSTANTS.DEFAULT_STAMINA;
+      return Number(DEFAULT_CONSTANTS.DEFAULT_STAMINA);
     case 'DEFAULT_CRIT_RATE':
-      return DEFAULT_CONSTANTS.DEFAULT_CRIT_RATE;
+      return Number(DEFAULT_CONSTANTS.DEFAULT_CRIT_RATE);
     case 'DEFAULT_VOL':
-      return DEFAULT_CONSTANTS.DEFAULT_VOL;
+      return Number(DEFAULT_CONSTANTS.DEFAULT_VOL);
     case 'DEFAULT_ACCURACY':
-      return DEFAULT_CONSTANTS.DEFAULT_ACCURACY;
+      return Number(DEFAULT_CONSTANTS.DEFAULT_ACCURACY);
     case 'SWITCH_PRIORITY':
-      return DEFAULT_CONSTANTS.SWITCH_PRIORITY;
+      return Number(DEFAULT_CONSTANTS.SWITCH_PRIORITY);
     case 'dynamic':
       // Dynamic values are calculated at runtime, return 0 as placeholder
       return 0;
@@ -141,13 +141,13 @@ export function convertMoveMetadata(raw: RawMoveMetadata): MoveMetadata {
     inheritsFrom: raw.inheritsFrom,
     name: raw.name,
     basePower: resolveConstant(raw.basePower),
-    staminaCost: resolveConstant(raw.staminaCost, DEFAULT_CONSTANTS.DEFAULT_STAMINA),
-    accuracy: resolveConstant(raw.accuracy, DEFAULT_CONSTANTS.DEFAULT_ACCURACY),
-    priority: resolveConstant(raw.priority, DEFAULT_CONSTANTS.DEFAULT_PRIORITY),
+    staminaCost: resolveConstant(raw.staminaCost, Number(DEFAULT_CONSTANTS.DEFAULT_STAMINA)),
+    accuracy: resolveConstant(raw.accuracy, Number(DEFAULT_CONSTANTS.DEFAULT_ACCURACY)),
+    priority: resolveConstant(raw.priority, Number(DEFAULT_CONSTANTS.DEFAULT_PRIORITY)),
     moveType: resolveMoveType(raw.moveType),
     moveClass: resolveMoveClass(raw.moveClass),
-    critRate: resolveConstant(raw.critRate, DEFAULT_CONSTANTS.DEFAULT_CRIT_RATE),
-    volatility: resolveConstant(raw.volatility, DEFAULT_CONSTANTS.DEFAULT_VOL),
+    critRate: resolveConstant(raw.critRate, Number(DEFAULT_CONSTANTS.DEFAULT_CRIT_RATE)),
+    volatility: resolveConstant(raw.volatility, Number(DEFAULT_CONSTANTS.DEFAULT_VOL)),
     effectAccuracy: resolveConstant(raw.effectAccuracy),
     effect: raw.effect,
     extraDataType: resolveExtraDataType(raw.extraDataType),

--- a/client/lib/types.ts
+++ b/client/lib/types.ts
@@ -1,85 +1,85 @@
 /**
- * Type definitions for Chomp battle system metadata
+ * Type definitions for Chomp battle system
  *
- * IMPORTANT: The enums and constants defined here mirror the Solidity source
- * in src/Enums.sol and src/Constants.sol. When the transpiler generates
- * ts-output/Enums.ts and ts-output/Constants.ts, those become the source of truth.
- *
- * For client code that needs compile-time types before transpilation,
- * these definitions serve as fallbacks that MUST match the Solidity source.
- *
- * Usage patterns:
- * 1. Build-time types (before transpilation): Import directly from this file
- * 2. Runtime (after transpilation): The BattleHarness loads transpiled code dynamically
- *
- * To verify these match Solidity, run the transpiler and compare:
- *   python3 transpiler/sol2ts.py src/Enums.sol -o /tmp/enums-check
+ * Enums and constants are imported directly from the transpiled Solidity output.
+ * Client-specific types (BattleState, MoveMetadata, etc.) are defined here.
  */
 
 // =============================================================================
-// ENUMS (mirrors src/Enums.sol)
+// IMPORTS FROM TRANSPILED SOLIDITY
+// =============================================================================
+
+// Import enums from transpiled Enums.ts (source: src/Enums.sol)
+import {
+  Type,
+  MoveClass,
+  ExtraDataType,
+  MonStateIndexName,
+  GameStatus,
+  EffectStep,
+  EffectRunCondition,
+  StatBoostType,
+  StatBoostFlag,
+} from '../../transpiler/ts-output/Enums';
+
+// Import constants from transpiled Constants.ts (source: src/Constants.sol)
+import {
+  NO_OP_MOVE_INDEX,
+  SWITCH_MOVE_INDEX,
+  SWITCH_PRIORITY,
+  DEFAULT_PRIORITY,
+  DEFAULT_STAMINA,
+  DEFAULT_CRIT_RATE,
+  DEFAULT_VOL,
+  DEFAULT_ACCURACY,
+  CRIT_NUM,
+  CRIT_DENOM,
+} from '../../transpiler/ts-output/Constants';
+
+// =============================================================================
+// RE-EXPORTS WITH ALIASES
+// =============================================================================
+
+// Re-export Type as MoveType for backwards compatibility
+// (Solidity uses "Type" but "MoveType" is clearer in client context)
+export { Type as MoveType };
+
+// Re-export other enums directly
+export {
+  MoveClass,
+  ExtraDataType,
+  MonStateIndexName,
+  GameStatus,
+  EffectStep,
+  EffectRunCondition,
+  StatBoostType,
+  StatBoostFlag,
+};
+
+// =============================================================================
+// CONSTANTS (re-exported with client-friendly format)
 // =============================================================================
 
 /**
- * Element types for mons and moves.
- * @see src/Enums.sol - Type enum
+ * Game constants from src/Constants.sol
+ * Values are bigint to match transpiled output.
  */
-export enum MoveType {
-  Yin = 0,
-  Yang = 1,
-  Earth = 2,
-  Liquid = 3,
-  Fire = 4,
-  Metal = 5,
-  Ice = 6,
-  Nature = 7,
-  Lightning = 8,
-  Mythic = 9,
-  Air = 10,
-  Math = 11,
-  Cyber = 12,
-  Wild = 13,
-  Cosmic = 14,
-  None = 15,
-}
+export const DEFAULT_CONSTANTS = {
+  DEFAULT_PRIORITY,
+  DEFAULT_STAMINA,
+  DEFAULT_CRIT_RATE,
+  DEFAULT_VOL,
+  DEFAULT_ACCURACY,
+  SWITCH_PRIORITY,
+  CRIT_NUM,
+  CRIT_DENOM,
+  NO_OP_MOVE_INDEX,
+  SWITCH_MOVE_INDEX,
+} as const;
 
-/**
- * Move classification for damage calculation.
- * @see src/Enums.sol - MoveClass enum
- */
-export enum MoveClass {
-  Physical = 0,
-  Special = 1,
-  Self = 2,
-  Other = 3,
-}
-
-/**
- * Types of extra data a move may require.
- * @see src/Enums.sol - ExtraDataType enum
- */
-export enum ExtraDataType {
-  None = 0,
-  SelfTeamIndex = 1,
-}
-
-/**
- * Index names for mon state array access.
- * @see src/Enums.sol - MonStateIndexName enum
- */
-export enum MonStateIndexName {
-  Hp = 0,
-  Stamina = 1,
-  Speed = 2,
-  Attack = 3,
-  Defense = 4,
-  SpecialAttack = 5,
-  SpecialDefense = 6,
-  IsKnockedOut = 7,
-  ShouldSkipTurn = 8,
-  Type1 = 9,
-  Type2 = 10,
-}
+// =============================================================================
+// CLIENT-SPECIFIC TYPES
+// =============================================================================
 
 /**
  * Raw move metadata as extracted from Solidity files
@@ -101,7 +101,6 @@ export interface RawMoveMetadata {
   effectAccuracy: string | number;
   effect: string | null;
   extraDataType: string;
-  // Additional custom fields for non-StandardAttack moves
   customConstants?: Record<string, string | number>;
   customBehavior?: string;
 }
@@ -119,11 +118,11 @@ export interface MoveMetadata {
   staminaCost: number;
   accuracy: number;
   priority: number;
-  moveType: MoveType;
+  moveType: Type;
   moveClass: MoveClass;
   critRate: number;
-  volatility: number;
   effectAccuracy: number;
+  volatility: number;
   effect: string | null;
   extraDataType: ExtraDataType;
   customConstants?: Record<string, number>;
@@ -135,7 +134,7 @@ export interface MoveMetadata {
  */
 export interface MonDefinition {
   name: string;
-  types: [MoveType, MoveType];
+  types: [Type, Type];
   baseStats: {
     hp: number;
     attack: number;
@@ -144,7 +143,7 @@ export interface MonDefinition {
     specialDefense: number;
     speed: number;
   };
-  moves: string[]; // Contract names
+  moves: string[];
   ability?: string;
 }
 
@@ -161,8 +160,8 @@ export interface MonBattleState {
   specialDefense: bigint;
   isKnockedOut: boolean;
   shouldSkipTurn: boolean;
-  type1: MoveType;
-  type2: MoveType;
+  type1: Type;
+  type2: Type;
 }
 
 /**
@@ -217,49 +216,9 @@ export interface BattleEvent {
  * Configuration for the battle service
  */
 export interface BattleServiceConfig {
-  /** RPC URL for on-chain interactions (optional for local simulation) */
   rpcUrl?: string;
-  /** Chain ID (default: 1 for mainnet) */
   chainId?: number;
-  /** Engine contract address (required for on-chain mode) */
   engineAddress?: `0x${string}`;
-  /** Type calculator contract address */
   typeCalculatorAddress?: `0x${string}`;
-  /** Enable local simulation mode (default: true) */
   localSimulation?: boolean;
 }
-
-// =============================================================================
-// CONSTANTS (mirrors src/Constants.sol)
-// =============================================================================
-
-/**
- * Default constant values from src/Constants.sol
- *
- * IMPORTANT: These values MUST match the Solidity source. When the transpiler
- * generates ts-output/Constants.ts, that becomes the source of truth.
- *
- * @see src/Constants.sol
- */
-export const DEFAULT_CONSTANTS = {
-  /** Default move priority (most moves use this) */
-  DEFAULT_PRIORITY: 3,
-  /** Default stamina cost for moves */
-  DEFAULT_STAMINA: 5,
-  /** Default critical hit rate (5% = 5/100) */
-  DEFAULT_CRIT_RATE: 5,
-  /** Default damage volatility */
-  DEFAULT_VOL: 10,
-  /** Default accuracy (100 = never misses) */
-  DEFAULT_ACCURACY: 100,
-  /** Priority for switch actions (higher = goes first) */
-  SWITCH_PRIORITY: 6,
-  /** Critical hit damage numerator (3/2 = 1.5x) */
-  CRIT_NUM: 3,
-  /** Critical hit damage denominator */
-  CRIT_DENOM: 2,
-  /** Special move index for no-op (skip turn) */
-  NO_OP_MOVE_INDEX: 126,
-  /** Special move index for switching mons */
-  SWITCH_MOVE_INDEX: 125,
-} as const;

--- a/client/lib/types.ts
+++ b/client/lib/types.ts
@@ -1,9 +1,29 @@
 /**
  * Type definitions for Chomp battle system metadata
- * These types mirror the Solidity enums and structs
+ *
+ * IMPORTANT: The enums and constants defined here mirror the Solidity source
+ * in src/Enums.sol and src/Constants.sol. When the transpiler generates
+ * ts-output/Enums.ts and ts-output/Constants.ts, those become the source of truth.
+ *
+ * For client code that needs compile-time types before transpilation,
+ * these definitions serve as fallbacks that MUST match the Solidity source.
+ *
+ * Usage patterns:
+ * 1. Build-time types (before transpilation): Import directly from this file
+ * 2. Runtime (after transpilation): The BattleHarness loads transpiled code dynamically
+ *
+ * To verify these match Solidity, run the transpiler and compare:
+ *   python3 transpiler/sol2ts.py src/Enums.sol -o /tmp/enums-check
  */
 
-// Mirrors src/Enums.sol
+// =============================================================================
+// ENUMS (mirrors src/Enums.sol)
+// =============================================================================
+
+/**
+ * Element types for mons and moves.
+ * @see src/Enums.sol - Type enum
+ */
 export enum MoveType {
   Yin = 0,
   Yang = 1,
@@ -23,6 +43,10 @@ export enum MoveType {
   None = 15,
 }
 
+/**
+ * Move classification for damage calculation.
+ * @see src/Enums.sol - MoveClass enum
+ */
 export enum MoveClass {
   Physical = 0,
   Special = 1,
@@ -30,11 +54,19 @@ export enum MoveClass {
   Other = 3,
 }
 
+/**
+ * Types of extra data a move may require.
+ * @see src/Enums.sol - ExtraDataType enum
+ */
 export enum ExtraDataType {
   None = 0,
   SelfTeamIndex = 1,
 }
 
+/**
+ * Index names for mon state array access.
+ * @see src/Enums.sol - MonStateIndexName enum
+ */
 export enum MonStateIndexName {
   Hp = 0,
   Stamina = 1,
@@ -197,18 +229,37 @@ export interface BattleServiceConfig {
   localSimulation?: boolean;
 }
 
+// =============================================================================
+// CONSTANTS (mirrors src/Constants.sol)
+// =============================================================================
+
 /**
  * Default constant values from src/Constants.sol
+ *
+ * IMPORTANT: These values MUST match the Solidity source. When the transpiler
+ * generates ts-output/Constants.ts, that becomes the source of truth.
+ *
+ * @see src/Constants.sol
  */
 export const DEFAULT_CONSTANTS = {
+  /** Default move priority (most moves use this) */
   DEFAULT_PRIORITY: 3,
+  /** Default stamina cost for moves */
   DEFAULT_STAMINA: 5,
+  /** Default critical hit rate (5% = 5/100) */
   DEFAULT_CRIT_RATE: 5,
+  /** Default damage volatility */
   DEFAULT_VOL: 10,
+  /** Default accuracy (100 = never misses) */
   DEFAULT_ACCURACY: 100,
+  /** Priority for switch actions (higher = goes first) */
   SWITCH_PRIORITY: 6,
+  /** Critical hit damage numerator (3/2 = 1.5x) */
   CRIT_NUM: 3,
+  /** Critical hit damage denominator */
   CRIT_DENOM: 2,
+  /** Special move index for no-op (skip turn) */
   NO_OP_MOVE_INDEX: 126,
+  /** Special move index for switching mons */
   SWITCH_MOVE_INDEX: 125,
 } as const;


### PR DESCRIPTION
## Summary
Refactored the BattleService to delegate local simulation logic to a new `BattleHarness` abstraction layer, improving separation of concerns and reducing direct Engine coupling. The service now composes the harness for battle logic while maintaining Angular-specific reactivity via signals.

## Key Changes

- **Introduced BattleHarness abstraction**: Replaced direct Engine imports and manual state management with a `BattleHarness` that handles module loading, caching, and dependency injection via `ContractContainer`

- **Simplified battle initialization**: Removed manual `battleConfig` and `battleData` setup (including `MockValidator` and `MockRNGOracle` classes) in favor of harness's `startBattle()` method that accepts structured `BattleConfig`

- **Streamlined turn execution**: Replaced direct `engine.setMove()` and `engine.execute()` calls with `harness.executeTurn()` that accepts a `TurnInput` struct

- **Updated state conversion**: Changed `updateBattleStateFromEngine()` to `updateBattleStateFromHarness()` with proper conversion from harness state (with stat deltas) to client state

- **Consolidated type imports**: Moved enum and constant definitions to import directly from transpiled Solidity output (`Enums.ts`, `Constants.ts`) rather than hardcoding them, ensuring consistency with contract definitions

- **Improved metadata converter**: Updated `resolveConstant()` to properly convert bigint constants from transpiled output to numbers for client use

- **Added harness accessor**: Exposed `getHarness()` method for advanced usage scenarios

## Implementation Details

- The harness uses a module loader function that accepts dynamic imports, enabling cached loading of transpiled Engine modules
- Battle state now properly tracks stat deltas from the harness and converts them to client-facing `MonBattleState` objects
- Removed ~100 lines of boilerplate mock implementations and manual state management
- Maintained backward compatibility with existing `MonConfig` and `TeamConfig` types exported from the harness

https://claude.ai/code/session_01DRERFdByBBTi7GM2Uj2Asj